### PR TITLE
Add support for HTML popups

### DIFF
--- a/CodeComplice.py
+++ b/CodeComplice.py
@@ -217,6 +217,28 @@ def tooltip_popup(view, snippets):
 
     sublime.set_timeout(open_auto_complete, 0)
 
+def tooltip_tooltip(view, snippets):
+    css_file = settings_manager.get('codeintel_tooltip_css_file', default='CodeComplice/css/default.css')
+
+    try:
+        css = sublime.load_resource('Packages/{}'.format(css_file))
+    except IOError:
+        logger(view, 'warning', 'Could not find CSS file "{}", loading default'.format(css_file))
+        css = sublime.load_resource('Packages/CodeComplice/css/default.css')
+
+    output = '<style>{}</style>'.format(css.replace('\r', ''))
+
+    lines = []
+
+    for snippet in snippets:
+        lines.append(snippet[0])
+
+    output += '<h1>{}</h1>'.format(lines[0])
+    output += '<div>{}</div>'.format('<br />'.join(lines[1:]))
+
+    view.show_popup(output, max_width=600)
+
+
 def tooltip(view, calltips, text_in_current_line, original_pos, lang, caller):
     def _insert_snippet():
         # Check to see we are still at a position where the snippet is wanted:
@@ -301,6 +323,8 @@ def tooltip(view, calltips, text_in_current_line, original_pos, lang, caller):
 
     if codeintel_tooltips == 'popup':
         tooltip_popup(view, snippets)
+    elif codeintel_tooltips == 'tooltip':
+        tooltip_tooltip(view, snippets)
     elif codeintel_tooltips in ('status', 'panel'):
         if codeintel_tooltips == 'status':
             set_status(view, 'tip', text, timeout=15000)
@@ -1209,6 +1233,7 @@ class SettingsManager():
     #you can set these in your *.sublime-project file
     CORE_SETTINGS = [
         'codeintel',
+        'codeintel_tooltip_css_file',
         'codeintel_database_dir',
         'codeintel_enabled_languages',
         'codeintel_syntax_map'

--- a/CodeComplice.sublime-settings
+++ b/CodeComplice.sublime-settings
@@ -55,9 +55,22 @@
        "popup" - Uses Autocomplete popup for tooltips.
        "panel" - Uses the output panel for tooltips.
        "status" - Uses the status bar for tooltips (was the default).
+       "tooltip" - Uses new-style HTML tooltips (requires ST3 Build 3070 or later).
     */
     "codeintel_tooltips": "popup",
 
+    /*
+      CSS file for "tooltip"-type tooltips
+
+      File path is relative to Packages directory. Custom styling should be
+      placed under your "User" directory.
+
+      Built-in styles:
+      "CodeComplice/css/light.css" - Style to work with light themes
+      "CodeComplice/css/dark.css" - Style to work with dark themes
+      "CodeComplice/css/default.css" - Default style
+     */
+    "codeintel_tooltip_css_file": "CodeComplice/css/light.css",
 
     /*
        "buffer" - add word completions from current view

--- a/README.md
+++ b/README.md
@@ -225,3 +225,6 @@ License
 The plugin is based in code from the Open Komodo Editor and has a MPL license.
 
 Ported from Open Komodo by German M. Bravo (Kronuz).
+
+Uses CSS from [Intellitip](https://github.com/jbrooksuk/Intellitip) under the
+MIT License.

--- a/css/dark.css
+++ b/css/dark.css
@@ -1,0 +1,21 @@
+html {
+    background-color: #232628;
+    color: #CCCCCC;
+}
+
+body {
+    font-size: 12px;
+}
+
+a {
+    color: #6699cc;
+}
+
+b {
+    color: #cc99cc;
+}
+
+h1 {
+    color: #99cc99;
+    font-size: 14px;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -1,0 +1,7 @@
+body {
+    font-size: 12px;
+}
+
+h1 {
+    font-size: 14px;
+}

--- a/css/light.css
+++ b/css/light.css
@@ -1,0 +1,21 @@
+html {
+    background-color: #FAFDFF;
+    color: #4d4d4c;
+}
+
+body {
+    font-size: 12px;
+}
+
+a {
+    color: #3e999f;
+}
+
+b {
+    color: #8959a8;
+}
+
+h1 {
+    color: #718c00;
+    font-size: 14px;
+}


### PR DESCRIPTION
:sparkles: :fireworks:

This adds support for the new HTML-style popups (as per #18). I'm not sure if you want to change the default here, so I haven't included that in this patch, but happy to do so.

The approach here is based partially on Tern (marijnh/tern_for_sublime#61), as well as shamelessly stealing @jbrooksuk's CSS from Intellitip (with credit in the README). Screenshots below.

Default styling:
![screenshot 2015-03-12 11 49 11](https://cloud.githubusercontent.com/assets/21655/6610640/d5e756bc-c8ad-11e4-876c-a7a7e6f041dc.png)

Dark theme:
![screenshot 2015-03-12 11 49 58](https://cloud.githubusercontent.com/assets/21655/6610646/ee752e98-c8ad-11e4-836d-42c45323524b.png)

Light theme:
![screenshot 2015-03-12 11 50 22](https://cloud.githubusercontent.com/assets/21655/6610652/fe17ddbe-c8ad-11e4-9417-2a130abf7a6b.png)

Happy to further improve this as needed!

One thing in particular is that it loads in the CSS file every time it renders the tooltip. I haven't noticed any issues with this so far, due to the multithreading, but it could potentially be improved. This does have the advantage that you can live-edit your CSS though.

:shipit: